### PR TITLE
allow render buffer capacity to be specified

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delog"
-version = "0.1.1"
+version = "0.1.2"
 description = "Deferred logging, an implementation and extension of Rust's standard logging facade."
 authors = ["Nicolas Stalder <n@stalder.io>"]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
This was pretty useful for tracing long ongoing NFC transactions, where any particular log isn't going to be more than 1-2KB, but I want to store >50KB overall.  The default of storing 2x 50KB buffers won't work, but a 50KB buffer and a 3KB buffer work great.

So:

```rust
delog!(Delogger, 26*1024, Flusher);
static FLUSHER: Flusher = Flusher {};
```

Could also be this for the same space:

```rust
delog!(Delogger, 50*1024, 2*1024, Flusher);
static FLUSHER: Flusher = Flusher {};
```