### PR TITLE
feat: add `atomic-polyfill` to support more targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ features = ["example"]
 targets = []
 
 [dependencies]
+atomic-polyfill = "1.0.1"
 log = "0.4"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ features = ["example"]
 targets = []
 
 [dependencies]
-atomic-polyfill = "1.0.1"
+atomic-polyfill = "1"
 log = "0.4"
 
 [dev-dependencies]

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,4 +1,4 @@
-use core::sync::atomic::{AtomicUsize, Ordering};
+use atomic_polyfill::{AtomicUsize, Ordering};
 use core::{cmp, ptr};
 
 /// Semi-abstract characterization of the deferred loggers that the `delog!` macro produces.


### PR DESCRIPTION
Fixes #9 

CI builds for those targets can also be added and mentioned in README.
**critical-section** implementation is also required.