### PR TITLE
Add optional support for portable-atomic and release v0.1.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install rust
         run: rustup target add ${CARGO_BUILD_TARGET}
       - name: Build
-        run: cargo build
+        run: cargo build --features portable-atomic,portable-atomic/critical-section
 
   qemu-test:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,7 @@ jobs:
       matrix:
         rust:
           - stable
-    # ubuntu-latest still points to 18.04, which only has QEMU 2
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,17 @@ jobs:
       - name: Run non-QEMU tests
         run: make non-qemu-tests
 
+  build-thumbv6m-none-eabi:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_BUILD_TARGET: thumbv6m-none-eabi
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install rust
+        run: rustup target add ${CARGO_BUILD_TARGET}
+      - name: Build
+        run: cargo build
+
   qemu-test:
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.8] - 2025-08-21
 - add `portable-atomic` feature to replace `core::sync::atomic::AtomicUsize` with `portable_atomic::AtomicUsize`
 
 ## [0.1.7] - 2023-08-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- add `portable-atomic` feature to replace `core::sync::atomic::AtomicUsize` with `portable_atomic::AtomicUsize`
 
 ## [0.1.7] - 2023-08-17
 - fix breakage caused by using internal `log` APIs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ targets = []
 
 [dependencies]
 log = "0.4"
+portable-atomic = { version = "1", optional = true }
 
 [dev-dependencies]
 insta = "1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delog"
-version = "0.1.7"
+version = "0.1.8"
 description = "Deferred logging, an implementation and extension of Rust's standard logging facade."
 authors = ["Trussed Developers"]
 license = "Apache-2.0 OR MIT"

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -184,7 +184,7 @@ macro_rules! hexstr {
 ///
 /// assert_eq!(format!("{}", hex_str), "07A1FF|C7");
 /// ```
-pub fn HexStr<T: ?Sized, U: Unsigned, S: Separator>(value: &T) -> HexStr<T, U, S> {
+pub fn HexStr<T: ?Sized, U: Unsigned, S: Separator>(value: &T) -> HexStr<'_, T, U, S> {
     HexStr {
         value,
         _bytes_per_block: PhantomData,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,8 @@ static mut LOGGER: Option<&'static dyn logger::TryLogWithStatistics> = None;
 
 /// Returns a reference to the logger (as `TryLogWithStatistics` implementation)
 pub fn logger() -> &'static mut Option<&'static dyn logger::TryLogWithStatistics> {
+    // TODO: implement safe alternative
+    #[allow(static_mut_refs)]
     unsafe { &mut LOGGER }
 }
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,5 +1,10 @@
-use core::sync::atomic::{AtomicUsize, Ordering};
+use core::sync::atomic::Ordering;
 use core::{cmp, ptr};
+
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic::AtomicUsize;
+#[cfg(feature = "portable-atomic")]
+use portable_atomic::AtomicUsize;
 
 /// Semi-abstract characterization of the deferred loggers that the `delog!` macro produces.
 ///

--- a/src/render.rs
+++ b/src/render.rs
@@ -16,27 +16,7 @@ pub fn render_arguments<'a>(buf: &'a mut [u8], args: fmt::Arguments) -> &'a [u8]
 
 /// Render record, based on feature flags.
 pub fn render_record<'a>(buf: &'a mut [u8], record: &log::Record) -> &'a [u8] {
-    if cfg!(feature = "prefix-level") {
-        match (record.file(), record.line()) {
-            (Some(file), Some(line)) => render_arguments(
-                buf,
-                format_args!(
-                    "{}|{}|{}:{}: {}",
-                    record.level(),
-                    record.target(),
-                    file,
-                    line,
-                    record.args()
-                ),
-            ),
-            _ => render_arguments(
-                buf,
-                format_args!("{}|{}: {}", record.level(), record.target(), record.args()),
-            ),
-        }
-    } else {
-        render_arguments(buf, *record.args())
-    }
+    render_arguments(buf, *record.args())
 }
 
 // I don't get it, why isn't this implemented already?


### PR DESCRIPTION
Depends on: https://github.com/trussed-dev/delog/pull/24